### PR TITLE
Fix open-zeppelin tests to correcly work with NEON

### DIFF
--- a/test/proxy/Clones.behaviour.js
+++ b/test/proxy/Clones.behaviour.js
@@ -39,7 +39,7 @@ module.exports = function shouldBehaveLikeClone (createClone) {
       });
 
       describe('when sending some balance', function () {
-        const value = 10e5;
+        const value = 10e9;
 
         it('reverts', async function () {
           await expectRevert.unspecified(
@@ -67,7 +67,7 @@ module.exports = function shouldBehaveLikeClone (createClone) {
       });
 
       describe('when sending some balance', function () {
-        const value = 10e5;
+        const value = 10e9;
 
         beforeEach('creating proxy', async function () {
           this.proxy = (
@@ -103,7 +103,7 @@ module.exports = function shouldBehaveLikeClone (createClone) {
       });
 
       describe('when sending some balance', function () {
-        const value = 10e5;
+        const value = 10e9;
 
         it('reverts', async function () {
           await expectRevert.unspecified(
@@ -132,7 +132,7 @@ module.exports = function shouldBehaveLikeClone (createClone) {
       });
 
       describe('when sending some balance', function () {
-        const value = 10e5;
+        const value = 10e9;
 
         beforeEach('creating proxy', async function () {
           this.proxy = (

--- a/test/proxy/Proxy.behaviour.js
+++ b/test/proxy/Proxy.behaviour.js
@@ -59,7 +59,7 @@ module.exports = function shouldBehaveLikeProxy (createProxy, proxyAdminAddress,
     });
 
     describe('when sending some balance', function () {
-      const value = 10e5;
+      const value = 10e9;
 
       beforeEach('creating proxy', async function () {
         this.proxy = (
@@ -95,7 +95,7 @@ module.exports = function shouldBehaveLikeProxy (createProxy, proxyAdminAddress,
       });
 
       describe('when sending some balance', function () {
-        const value = 10e5;
+        const value = 10e9;
 
         it('reverts', async function () {
           await expectRevert.unspecified(
@@ -125,7 +125,7 @@ module.exports = function shouldBehaveLikeProxy (createProxy, proxyAdminAddress,
       });
 
       describe('when sending some balance', function () {
-        const value = 10e5;
+        const value = 10e9;
 
         beforeEach('creating proxy', async function () {
           this.proxy = (
@@ -166,7 +166,7 @@ module.exports = function shouldBehaveLikeProxy (createProxy, proxyAdminAddress,
       });
 
       describe('when sending some balance', function () {
-        const value = 10e5;
+        const value = 10e9;
 
         it('reverts', async function () {
           await expectRevert.unspecified(
@@ -197,7 +197,7 @@ module.exports = function shouldBehaveLikeProxy (createProxy, proxyAdminAddress,
       });
 
       describe('when sending some balance', function () {
-        const value = 10e5;
+        const value = 10e9;
 
         beforeEach('creating proxy', async function () {
           this.proxy = (

--- a/test/proxy/beacon/BeaconProxy.test.js
+++ b/test/proxy/beacon/BeaconProxy.test.js
@@ -69,7 +69,7 @@ contract('BeaconProxy', function (accounts) {
 
     it('no initialization', async function () {
       const data = Buffer.from('');
-      const balance = '10';
+      const balance = '10000000000';
       this.proxy = await BeaconProxy.new(this.beacon.address, data, { value: balance });
       await this.assertInitialized({ value: '0', balance });
     });
@@ -88,7 +88,7 @@ contract('BeaconProxy', function (accounts) {
       const data = this.implementationV0.contract.methods
         .initializePayableWithValue(value)
         .encodeABI();
-      const balance = '100';
+      const balance = '100000000000';
       this.proxy = await BeaconProxy.new(this.beacon.address, data, { value: balance });
       await this.assertInitialized({ value, balance });
     });

--- a/test/proxy/transparent/TransparentUpgradeableProxy.behaviour.js
+++ b/test/proxy/transparent/TransparentUpgradeableProxy.behaviour.js
@@ -108,7 +108,7 @@ module.exports = function shouldBehaveLikeTransparentUpgradeableProxy (createPro
 
         describe('when the sender is the admin', function () {
           const from = proxyAdminAddress;
-          const value = 1e5;
+          const value = 1e9;
 
           beforeEach(async function () {
             this.receipt = await this.proxy.upgradeToAndCall(this.behavior.address, initializeData, { from, value });

--- a/test/security/PullPayment.test.js
+++ b/test/security/PullPayment.test.js
@@ -15,23 +15,23 @@ contract('PullPayment', function (accounts) {
 
   describe('payments', function () {
     it('can record an async payment correctly', async function () {
-      await this.contract.callTransfer(payee1, 100, { from: payer });
-      expect(await this.contract.payments(payee1)).to.be.bignumber.equal('100');
+      await this.contract.callTransfer(payee1, 100e9, { from: payer });
+      expect(await this.contract.payments(payee1)).to.be.bignumber.equal('100000000000');
     });
 
     it('can add multiple balances on one account', async function () {
-      await this.contract.callTransfer(payee1, 200, { from: payer });
-      await this.contract.callTransfer(payee1, 300, { from: payer });
-      expect(await this.contract.payments(payee1)).to.be.bignumber.equal('500');
+      await this.contract.callTransfer(payee1, 200e9, { from: payer });
+      await this.contract.callTransfer(payee1, 300e9, { from: payer });
+      expect(await this.contract.payments(payee1)).to.be.bignumber.equal('500000000000');
     });
 
     it('can add balances on multiple accounts', async function () {
-      await this.contract.callTransfer(payee1, 200, { from: payer });
-      await this.contract.callTransfer(payee2, 300, { from: payer });
+      await this.contract.callTransfer(payee1, 200e9, { from: payer });
+      await this.contract.callTransfer(payee2, 300e9, { from: payer });
 
-      expect(await this.contract.payments(payee1)).to.be.bignumber.equal('200');
+      expect(await this.contract.payments(payee1)).to.be.bignumber.equal('200000000000');
 
-      expect(await this.contract.payments(payee2)).to.be.bignumber.equal('300');
+      expect(await this.contract.payments(payee2)).to.be.bignumber.equal('300000000000');
     });
   });
 

--- a/test/utils/escrow/ConditionalEscrow.test.js
+++ b/test/utils/escrow/ConditionalEscrow.test.js
@@ -12,7 +12,9 @@ contract('ConditionalEscrow', function (accounts) {
 
   context('when withdrawal is allowed', function () {
     beforeEach(async function () {
-      await Promise.all(otherAccounts.map(payee => this.escrow.setAllowed(payee, true)));
+      for (const payee of otherAccounts) {
+          await this.escrow.setAllowed(payee, true);
+      }
     });
 
     shouldBehaveLikeEscrow(owner, otherAccounts);

--- a/test/utils/escrow/ConditionalEscrow.test.js
+++ b/test/utils/escrow/ConditionalEscrow.test.js
@@ -13,7 +13,7 @@ contract('ConditionalEscrow', function (accounts) {
   context('when withdrawal is allowed', function () {
     beforeEach(async function () {
       for (const payee of otherAccounts) {
-          await this.escrow.setAllowed(payee, true);
+        await this.escrow.setAllowed(payee, true);
       }
     });
 

--- a/test/utils/escrow/RefundEscrow.test.js
+++ b/test/utils/escrow/RefundEscrow.test.js
@@ -60,7 +60,9 @@ contract('RefundEscrow', function (accounts) {
 
     context('closed state', function () {
       beforeEach(async function () {
-        await Promise.all(refundees.map(refundee => this.escrow.deposit(refundee, { from: owner, value: amount })));
+        for (const refundee of refundees) {
+          await this.escrow.deposit(refundee, { from: owner, value: amount });
+        }
 
         await this.escrow.close({ from: owner });
       });
@@ -107,7 +109,9 @@ contract('RefundEscrow', function (accounts) {
 
     context('refund state', function () {
       beforeEach(async function () {
-        await Promise.all(refundees.map(refundee => this.escrow.deposit(refundee, { from: owner, value: amount })));
+        for (const refundee of refundees) {
+          await this.escrow.deposit(refundee, { from: owner, value: amount });
+        }
 
         await this.escrow.enableRefunds({ from: owner });
       });


### PR DESCRIPTION
1. Fix proxy tests to correctly send values (NEON is 9 decimals compared to 18 decimals Ether)
2. Fix escrow error - same nonce in different transactions